### PR TITLE
Added cyclomatic complexity workflow test on push

### DIFF
--- a/.github/workflows/cyclomatic-complexity.yml
+++ b/.github/workflows/cyclomatic-complexity.yml
@@ -1,0 +1,15 @@
+name: Cyclomatic Complexity Check
+
+on: [push]
+
+jobs:
+  radon:
+    runs-on: ubuntu-latest
+    name: "radon"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: davidslusser/actions_python_radon@v1.0.0
+        with:
+          src: "src"
+          min: "A"
+          grade: "B"

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -5,15 +5,12 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10"]
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
A big component of this class was dedicated to finding cyclomatic complexity of functions. This workflow makes it so that our functions are less complex and more readable and refactorable.

The default configuration uses radon, a pip package and runs the command with the following arguments:
`radon cc -s -a --min B `

Radon defines a "grade" for each file:
```
CC score 	Rank 	Risk
1 - 5 	        A 	low - simple block
6 - 10 	        B 	low - well structured and stable block
11 - 20 	C 	moderate - slightly complex block
21 - 30 	D 	more than moderate - more complex block
31 - 40 	E 	high - complex block, alarming
41+ 	        F 	very high - error-prone, unstable block
```
In our case, a minimum grade to pass should be "B"